### PR TITLE
It is better to use the repository field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 edition = "2021"
 authors = ["Ammar Dev"]
 description = "A simple library/crate to create and read and write json"
-homepage = "https://github.com/ammardevz/rusty_json"
+repository = "https://github.com/ammardevz/rusty_json"
 license = "MIT"
 
 


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.